### PR TITLE
Add unread message badges across the portal

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -29,7 +29,11 @@ export const Sidebar = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   const unreadNotifications = notifications.filter((n) => !n.read).length;
-  const pendingMessages = messages.filter((m) => m.status === 'pendiente' && !m.isFromAdvisor).length;
+  const newMessagesCount = messages.filter(
+    (m) => !m.isFromAdvisor && (!m.visto || m.status === 'pendiente')
+  ).length;
+  const displayNewMessagesCount = newMessagesCount > 99 ? '99+' : newMessagesCount;
+  const hasNewMessages = newMessagesCount > 0;
 
   const displayName = user?.name || user?.email || 'Usuario';
   const initials = displayName
@@ -85,6 +89,22 @@ export const Sidebar = () => {
               <h1 className="text-base font-semibold text-foreground">FinanceAdvisor</h1>
               <p className="text-xs text-muted-foreground">Panel Profesional</p>
             </div>
+          </Link>
+
+          <Link
+            to="/messages"
+            className="p-2 rounded-md text-foreground hover:bg-muted relative"
+            onClick={() => setIsSidebarOpen(false)}
+          >
+            <MessageCircle className="h-6 w-6" />
+            {hasNewMessages && (
+              <Badge
+                variant="destructive"
+                className="absolute -top-1 -right-1 h-5 min-w-[1.25rem] px-1 text-xs leading-none flex items-center justify-center"
+              >
+                {displayNewMessagesCount}
+              </Badge>
+            )}
           </Link>
         </div>
       </header>
@@ -143,7 +163,7 @@ export const Sidebar = () => {
                   key={item.name}
                   to={item.href}
                   className={`
-                    flex items-center px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                    relative flex items-center px-3 py-2 rounded-lg text-sm font-medium transition-colors
                     ${active
                       ? 'bg-primary text-primary-foreground shadow-sm'
                       : 'text-muted-foreground hover:bg-muted hover:text-foreground'
@@ -158,10 +178,18 @@ export const Sidebar = () => {
                       {unreadNotifications}
                     </Badge>
                   )}
-                  {item.name === 'Mensajes' && pendingMessages > 0 && (
-                    <Badge variant="secondary" className="ml-2 h-5 px-2 text-xs">
-                      {pendingMessages}
-                    </Badge>
+                  {item.name === 'Mensajes' && hasNewMessages && (
+                    <>
+                      <Badge
+                        variant="destructive"
+                        className="hidden lg:flex absolute -top-1 -right-1 h-5 min-w-[1.25rem] px-1 text-xs leading-none items-center justify-center"
+                      >
+                        {displayNewMessagesCount}
+                      </Badge>
+                      <Badge variant="secondary" className="lg:hidden ml-2 h-5 px-2 text-xs">
+                        {displayNewMessagesCount}
+                      </Badge>
+                    </>
                   )}
                 </NavLink>
               );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -29,7 +29,7 @@ export const Dashboard = () => {
   // Statistics
   const totalClients = clients.length;
   const pendingMessages = messages.filter(
-    (m) => m.status === 'pendiente' && !m.isFromAdvisor
+    (m) => !m.isFromAdvisor && (!m.visto || m.status === 'pendiente')
   ).length;
   const unreadNotifications = notifications.filter((n) => !n.read).length;
   const clientsNoContact = clients.filter(
@@ -110,7 +110,7 @@ export const Dashboard = () => {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="relative">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Mensajes Pendientes</CardTitle>
             <MessageCircle className="h-4 w-4 text-muted-foreground" />
@@ -119,6 +119,14 @@ export const Dashboard = () => {
             <div className="text-2xl font-bold text-warning">{pendingMessages}</div>
             <p className="text-xs text-muted-foreground">Requieren respuesta</p>
           </CardContent>
+          {pendingMessages > 0 && (
+            <Badge
+              variant="destructive"
+              className="absolute -top-2 -right-2 h-6 min-w-[1.5rem] px-1 text-xs leading-none flex items-center justify-center"
+            >
+              {pendingMessages > 99 ? '99+' : pendingMessages}
+            </Badge>
+          )}
         </Card>
 
         <Card>

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -2,15 +2,21 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { MessageCircle, Search } from 'lucide-react';
 import { useDataStore } from '@/stores/dataStore';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
+import { Badge } from '@/components/ui/badge';
 
 export const Messages = () => {
   const { messages, clients } = useDataStore();
   const [searchTerm, setSearchTerm] = useState('');
+
+  const newMessagesCount = messages.filter(
+    (msg) => !msg.isFromAdvisor && (!msg.visto || msg.status === 'pendiente')
+  ).length;
+  const displayNewMessagesCount = newMessagesCount > 99 ? '99+' : newMessagesCount;
+  const hasNewMessages = newMessagesCount > 0;
 
   // Filtrar clientes que tengan mensajes y coincidan con el término de búsqueda
   const filteredClients = clients
@@ -47,12 +53,30 @@ export const Messages = () => {
     <div className="flex-1 p-6 space-y-6 pt-16 lg:pt-0">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-foreground">Centro de Mensajes</h1>
-          <p className="text-muted-foreground">
-            Gestiona todas las comunicaciones con tus clientes
-          </p>
+        <div className="flex items-start gap-3">
+          <div className="relative lg:hidden">
+            <MessageCircle className="h-10 w-10 text-primary" />
+            {hasNewMessages && (
+              <Badge
+                variant="destructive"
+                className="absolute -top-1 -right-1 h-6 min-w-[1.5rem] px-1 text-xs leading-none flex items-center justify-center"
+              >
+                {displayNewMessagesCount}
+              </Badge>
+            )}
+          </div>
+          <div>
+            <h1 className="text-3xl font-bold text-foreground">Centro de Mensajes</h1>
+            <p className="text-muted-foreground">
+              Gestiona todas las comunicaciones con tus clientes
+            </p>
+          </div>
         </div>
+        {hasNewMessages && (
+          <Badge className="hidden lg:inline-flex h-6 min-w-[1.5rem] px-2 text-xs items-center justify-center">
+            {displayNewMessagesCount}
+          </Badge>
+        )}
       </div>
 
       {/* Search Bar */}


### PR DESCRIPTION
## Summary
- add responsive badge indicators for unread client messages in the sidebar navigation
- surface unread message counts in the messages page header for desktop and mobile
- show a prominent badge on the dashboard pending messages card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e55b1e51808330940cbf068647c4dd