### PR TITLE
Show client metrics in desktop table

### DIFF
--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -229,6 +229,8 @@ export const Clients = () => {
                     <TableHead>Contacto</TableHead>
                     <TableHead>Perfil</TableHead>
                     <TableHead>Broker</TableHead>
+                    <TableHead className="text-center">Mensajes</TableHead>
+                    <TableHead className="text-center">Documentos</TableHead>
                     <TableHead className="text-center">Acciones</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -273,6 +275,29 @@ export const Clients = () => {
                           {client.broker}
                         </TableCell>
                         
+                        <TableCell className="text-center">
+                          <div className="flex justify-center">
+                            {stats.pendingMessages > 0 ? (
+                              <Badge variant="destructive" className="gap-1">
+                                <MessageCircle className="h-3 w-3" />
+                                {stats.pendingMessages} pendiente(s)
+                              </Badge>
+                            ) : (
+                              <Badge variant="outline" className="gap-1 text-muted-foreground">
+                                <MessageCircle className="h-3 w-3" />
+                                Sin pendientes
+                              </Badge>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <div className="flex justify-center">
+                            <Badge variant="secondary" className="gap-1">
+                              <FileText className="h-3 w-3" />
+                              {stats.totalDocuments} doc(s)
+                            </Badge>
+                          </div>
+                        </TableCell>
                         <TableCell className="text-right">
                           <div className="flex items-center justify-end space-x-2">
                             <Button


### PR DESCRIPTION
## Summary
- add mensajes and documentos columns to the desktop clients table
- display badges that highlight pending conversations and available documents for each client

## Testing
- npm run lint *(fails: existing lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e56c291e648330baa7fcbf2aa42ce7