### PR TITLE
feat: store reports in firestore and storage

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -150,6 +150,8 @@ export const mockDocuments: Document[] = [
     description: 'Análisis detallado de performance de cartera enero 2024',
     uploadDate: new Date('2024-01-18T15:30:00'),
     size: 2048576,
+    fileUrl: '#',
+    storagePath: 'mock/reporte-performance-enero-2024.pdf',
     visibility: 'selected',
     clientIds: ['1']
   },
@@ -160,6 +162,8 @@ export const mockDocuments: Document[] = [
     description: 'Sugerencias de ajuste para perfil agresivo',
     uploadDate: new Date('2024-01-17T11:00:00'),
     size: 1536000,
+    fileUrl: '#',
+    storagePath: 'mock/recomendaciones-portfolio-agresivo.pdf',
     visibility: 'selected',
     clientIds: ['2']
   },
@@ -170,6 +174,8 @@ export const mockDocuments: Document[] = [
     description: 'Análisis semanal de condiciones del mercado',
     uploadDate: new Date('2024-01-16T09:45:00'),
     size: 3072000,
+    fileUrl: '#',
+    storagePath: 'mock/informe-mercado-semanal.pdf',
     visibility: 'all',
     clientIds: []
   },
@@ -180,6 +186,8 @@ export const mockDocuments: Document[] = [
     description: 'Plan de inversión conservador para 2024',
     uploadDate: new Date('2024-01-15T14:20:00'),
     size: 2560000,
+    fileUrl: '#',
+    storagePath: 'mock/estrategia-conservadora-2024.pdf',
     visibility: 'selected',
     clientIds: ['4']
   }

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -113,6 +113,15 @@ export const Reports = () => {
       return;
     }
 
+    if (!selectedFile) {
+      toast({
+        title: 'Adjunta un archivo',
+        description: 'Selecciona el documento que quieres compartir con tus clientes.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
     if (visibility === 'selected' && selectedClients.length === 0) {
       toast({
         title: 'Selecciona al menos un cliente',
@@ -124,14 +133,13 @@ export const Reports = () => {
 
     setIsSubmitting(true);
     try {
-      addDocument({
-        name: name.trim(),
-        description: description.trim(),
+      await addDocument({
+        name,
+        description,
         type,
-        uploadDate: new Date(),
-        size: selectedFile?.size ?? 0,
         visibility,
         clientIds: visibility === 'selected' ? selectedClients : [],
+        file: selectedFile,
       });
 
       toast({
@@ -143,8 +151,32 @@ export const Reports = () => {
       });
 
       resetForm();
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'No pudimos compartir el informe',
+        description: 'Intenta nuevamente. Si el problema persiste contacta al administrador.',
+        variant: 'destructive',
+      });
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (documentId: string) => {
+    try {
+      await deleteDocument(documentId);
+      toast({
+        title: 'Informe eliminado',
+        description: 'El informe y su archivo fueron eliminados correctamente.',
+      });
+    } catch (error) {
+      console.error(error);
+      toast({
+        title: 'No pudimos eliminar el informe',
+        description: 'Vuelve a intentarlo en unos segundos.',
+        variant: 'destructive',
+      });
     }
   };
 
@@ -419,7 +451,14 @@ export const Reports = () => {
                       <TableRow key={document.id}>
                         <TableCell>
                           <div className="space-y-1">
-                            <p className="font-medium">{document.name}</p>
+                            <a
+                              href={document.fileUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="font-medium text-primary hover:underline"
+                            >
+                              {document.name}
+                            </a>
                             {document.description && (
                               <p className="text-sm text-muted-foreground line-clamp-2">
                                 {document.description}
@@ -448,7 +487,7 @@ export const Reports = () => {
                             variant="ghost"
                             size="sm"
                             className="text-destructive hover:text-destructive"
-                            onClick={() => deleteDocument(document.id)}
+                            onClick={() => void handleDelete(document.id)}
                           >
                             <Trash2 className="h-4 w-4" />
                             <span className="sr-only">Eliminar informe</span>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,8 @@ export interface Document {
   description: string;
   uploadDate: Date;
   size: number;
+  fileUrl: string;
+  storagePath: string;
   visibility: 'all' | 'selected';
   clientIds: string[];
 }


### PR DESCRIPTION
## Summary
- upload advisor reports to Firebase Storage and persist metadata in Firestore
- update the reports UI to handle async uploads, deletions, and expose download links
- align shared types and mock data with the stored file information

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e573923178833094ad50141886e0cd