### PR TITLE
Add chat shortcut to clients list

### DIFF
--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -179,6 +179,15 @@ export const Clients = () => {
                         <Button
                           variant="outline"
                           size="sm"
+                          onClick={() => navigate(`/messages/${client.id}`)}
+                          className="gap-1"
+                        >
+                          <MessageCircle className="h-4 w-4" />
+                          Chat
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
                           onClick={() => navigate(`/clients/${client.id}`)}
                         >
                           Ver
@@ -302,6 +311,15 @@ export const Clients = () => {
                         </TableCell>
                         <TableCell className="text-right">
                           <div className="flex items-center justify-end space-x-2">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => navigate(`/messages/${client.id}`)}
+                              className="gap-1"
+                            >
+                              <MessageCircle className="h-4 w-4" />
+                              Chat
+                            </Button>
                             <Button
                               variant="outline"
                               size="sm"


### PR DESCRIPTION
## Summary
- add a Chat action button in the mobile and desktop client listings
- navigate directly to the client chat when the new button is pressed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5798675e0833090aefdf815ed11f6