### PR TITLE
Update chat message status icons

### DIFF
--- a/src/pages/ClientChat.tsx
+++ b/src/pages/ClientChat.tsx
@@ -9,8 +9,8 @@ import {
   Image as ImageIcon,
   FileText,
   FileDown,
+  Check,
   CheckCheck,
-  Clock,
 } from 'lucide-react';
 import { format } from 'date-fns';
 import { es } from 'date-fns/locale';
@@ -226,10 +226,7 @@ const ClientChat = () => {
                         {message.visto ? (
                           <CheckCheck className="h-4 w-4 text-emerald-500" aria-label="Mensaje visto" />
                         ) : (
-                          <Clock
-                            className="h-4 w-4 text-muted-foreground"
-                            aria-label="Mensaje pendiente de lectura"
-                          />
+                          <Check className="h-4 w-4 text-muted-foreground" aria-label="Mensaje enviado" />
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- replace the pending clock icon in the chat with a single gray checkmark
- keep read messages using the double green check icon for visual confirmation

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e66f42f8f88330b89794cf83aae876