### PR TITLE
Add global loading overlay while Firestore data loads

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,11 +1,14 @@
 import { Outlet, Navigate } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { Sidebar } from '@/components/Sidebar';
+import { useDataStore } from '@/stores/dataStore';
+import { LoadingOverlay } from '@/components/LoadingOverlay';
 
 export const Layout = () => {
-  const { isAuthenticated, isLoading } = useAuthStore();
+  const { isAuthenticated, isLoading: authLoading } = useAuthStore();
+  const isDataLoading = useDataStore((state) => state.isLoading);
 
-  if (isLoading) {
+  if (authLoading) {
     return (
       <div className="flex h-screen items-center justify-center bg-background">
         <span className="text-muted-foreground">Verificando sesión...</span>
@@ -18,11 +21,12 @@ export const Layout = () => {
   }
 
   return (
-    <div className="flex h-screen bg-background">
+    <div className="relative flex h-screen bg-background">
       <Sidebar />
       <main className="flex-1 overflow-y-auto">
         <Outlet />
       </main>
+      {isDataLoading ? <LoadingOverlay /> : null}
     </div>
   );
 };

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -1,0 +1,26 @@
+import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface LoadingOverlayProps {
+  message?: string;
+  className?: string;
+}
+
+export const LoadingOverlay = ({
+  message = 'Cargando información...',
+  className,
+}: LoadingOverlayProps) => {
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-50 flex flex-col items-center justify-center bg-background/80 backdrop-blur-sm',
+        className
+      )}
+    >
+      <Loader2 className="h-10 w-10 animate-spin text-primary" aria-hidden="true" />
+      <p className="mt-4 text-sm font-medium text-muted-foreground" role="status">
+        {message}
+      </p>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add a global loading state to the data store that resets when Firestore listeners start and clears after the first payload arrives
- render a reusable loading overlay component from the layout to cover the app while Firestore data is loading
- create a dedicated `LoadingOverlay` component for a consistent loader presentation across the app

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6882f53748330bab379acb7f6c86b